### PR TITLE
add force-run variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Force run (when ansible is used as a packer privisioner)
+force_run: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: check if nvme module loaded
-  lineinfile: 
+  lineinfile:
     dest: /proc/modules
     regex: '^nvme*'
     state: absent
@@ -10,7 +10,6 @@
 
 - name: proceed if nvme module is present
   import_tasks: 'configure_mapping.yml'
-  when:
-  - presence.changed
+  when: presence.changed or force_run | bool
 
 ...


### PR DESCRIPTION
add force-run variable to allow running regarding if nvme is present or not for cases when role is used to provision AMIs build with packer